### PR TITLE
Refactor to work with current version of WindowsAzure.Storage

### DIFF
--- a/AzureMediaPortal/Controllers/MediaController.cs
+++ b/AzureMediaPortal/Controllers/MediaController.cs
@@ -359,11 +359,15 @@ namespace AzureMediaPortal.Controllers
             string mediaAccountKey = ConfigurationManager.AppSettings["MediaAccountKey"];
             string storageAccountName = ConfigurationManager.AppSettings["StorageAccountName"];
             string storageAccountKey = ConfigurationManager.AppSettings["StorageAccountKey"];
+            string storageConnectionString = ConfigurationManager.AppSettings["StorageConnectionString"];
+            string storageContainerReference = ConfigurationManager.AppSettings["StorageContainerReference"];
 
             CloudMediaContext context = new CloudMediaContext(mediaAccountName, mediaAccountKey);
             var storageAccount = new CloudStorageAccount(new StorageCredentials(storageAccountName, storageAccountKey), true);
             var cloudBlobClient = storageAccount.CreateCloudBlobClient();
-            var mediaBlobContainer = cloudBlobClient.GetContainerReference(cloudBlobClient.BaseUri + "temporary-media");
+            var mediaBlobContainer = CloudStorageAccount.Parse(storageConnectionString)
+                .CreateCloudBlobClient()
+                .GetContainerReference(storageContainerReference);
 
             mediaBlobContainer.CreateIfNotExists();
 


### PR DESCRIPTION
When I updated the Nuget packages for WindowsAzure.Storage to version 6.2.0 I was getting an error so I refactored the code a bit and all works with old and new versions of package. Thanks for making this project, it was very helpful.
[azure-media-services-mvc-fix.pdf](https://github.com/dotnetcurry/azure-media-services-mvc/files/87568/azure-media-services-mvc-fix.pdf)
